### PR TITLE
Include eventfd for waking epoll_wait()

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -18,5 +18,6 @@
 #define SocketUtilities_h
 
 #include <sys/epoll.h>
+#include <sys/eventfd.h>
 
 #endif /* SelectUtilities_h */


### PR DESCRIPTION
A change to support HTTP Pipelining (IBM-Swift/Kitura#932) requires that we interrupt the `epoll_wait()` call when it is time to process any remaining buffered data.

This can be accomplished using `eventfd`s registered with the epoll descriptor, but `sys/eventfd.h` is required.